### PR TITLE
refactor(db): update add_employee to use double pointer

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -1,7 +1,10 @@
 #ifndef PARSE_H
 #define PARSE_H
 
-#define HEADER_MAGIC 0x41444D44
+#define HEADER_MAGIC 0x4c4c4144
+#define NAME_LEN 256
+#define ADDRESS_LEN 256
+
 
 struct dbheader_t {
 	unsigned int magic;
@@ -11,8 +14,8 @@ struct dbheader_t {
 };
 
 struct employee_t {
-	char name[256];
-	char address[256];
+	char name[NAME_LEN];
+	char address[ADDRESS_LEN];
 	unsigned int hours;
 };
 
@@ -21,6 +24,6 @@ int validate_db_header(int fd, struct dbheader_t **headerOut);
 int read_employees(int fd, struct dbheader_t *, struct employee_t **employeesOut);
 int output_file(int fd, struct dbheader_t *, struct employee_t *employees);
 void list_employees(struct dbheader_t *dbhdr, struct employee_t *employees);
-int add_employee(struct dbheader_t *dbhdr, struct employee_t *employees, char *addstring);
+int add_employee(struct dbheader_t *dbhdr, struct employee_t **employees, char *addstring);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -89,7 +89,7 @@ int main(int argc, char *argv[]) {
   if (addstring != NULL) {
     header->count++;
     employees = realloc(employees, header->count * (sizeof(struct employee_t)));
-    add_employee(header, employees, addstring);
+    add_employee(header, &employees, addstring);
   };
 
   output_file(dbfd, header, employees);

--- a/src/parse.c
+++ b/src/parse.c
@@ -13,19 +13,24 @@
 void list_employees(struct dbheader_t *dbhdr, struct employee_t *employees) {
 }
 
-int add_employee(struct dbheader_t *dbhdr, struct employee_t *employees, char *addstring) {
-  printf("%s\n", addstring);
+int add_employee(struct dbheader_t *dbhdr, struct employee_t **employees, char *addstring) {
+
+  if (employees == NULL) {
+    printf("Failed to create new employee\n");
+    return STATUS_ERROR;
+  };
+
   char *name = strtok(addstring, ",");
   char *address = strtok(NULL, ",");
   char *hours_string = strtok(NULL, ",");
   int hours = atoi(hours_string);
   int count = dbhdr->count;
   // employees->name = *name;
-  strncpy(employees[count - 1].name, name, sizeof(employees[count - 1].name));
-  strncpy(employees[count - 1].address, address, sizeof(employees[count - 1].address));
-  employees[count - 1].hours = hours;
+  strncpy((*employees)[count - 1].name, name, sizeof((*employees)[count - 1].name));
+  strncpy((*employees)[count - 1].address, address, sizeof((*employees)[count - 1].address));
+  (*employees)[count - 1].hours = hours;
 
-  dbhdr->filesize = dbhdr->filesize + sizeof(employees[count - 1]);
+  dbhdr->filesize = dbhdr->filesize + sizeof((*employees)[count - 1]);
 
   return STATUS_SUCCESS;
 };


### PR DESCRIPTION
The `add_employee` function has been updated to accept a double pointer for the `employees` parameter. This change was made to allow remote automated tests.
Magic value was updated for the same reason, to match the expected one.