### PR TITLE
Implement delete functionality

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -5,7 +5,7 @@
 #define NAME_LEN 256
 #define ADDRESS_LEN 256
 
-
+  
 struct dbheader_t {
 	unsigned int magic;
 	unsigned short version;
@@ -25,5 +25,6 @@ int read_employees(int fd, struct dbheader_t *, struct employee_t **employeesOut
 int output_file(int fd, struct dbheader_t *, struct employee_t *employees);
 void list_employees(struct dbheader_t *dbhdr, struct employee_t *employees);
 int add_employee(struct dbheader_t *dbhdr, struct employee_t **employees, char *addstring);
+int delete_employee(struct dbheader_t *dbhdr, struct employee_t **employees, char *delstring);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -22,8 +22,9 @@ int main(int argc, char *argv[]) {
   struct dbheader_t *header = NULL;
   struct employee_t *employees = NULL;
   char *addstring = NULL;
+  char *delstring = NULL;
 
-	while (( c = getopt(argc, argv, "nf:a:l")) != -1 ) {
+	while (( c = getopt(argc, argv, "nf:a:ld:")) != -1 ) {
 		switch(c){
 			case 'n':
 				newfile = true;
@@ -39,6 +40,10 @@ int main(int argc, char *argv[]) {
 
       case 'l':
         listdb = true;
+        break;
+
+      case 'd':
+        delstring = optarg;
         break;
 
 			case '?':
@@ -96,6 +101,12 @@ int main(int argc, char *argv[]) {
     employees = realloc(employees, header->count * (sizeof(struct employee_t)));
     add_employee(header, &employees, addstring);
   };
+
+  if (delstring != NULL) {
+    delete_employee(header, &employees, delstring);
+    header->count--;
+    employees = realloc(employees, header->count * (sizeof(struct employee_t)));
+  }
 
   if (listdb == true) {
     list_employees(header, employees);


### PR DESCRIPTION
This pull request introduces the ability for users to delete employees from the database via the command line.

Previously, it was only possible to add and list employees. This change implements the full lifecycle of an employee record by adding the functionality to remove them. A new -d command-line option has been added to accept the name of the employee to be deleted.

The implementation ensures that when an employee is deleted, the in-memory array is correctly shifted, the total employee count is updated, and the database file itself is truncated to the new, smaller size. This prevents file corruption and keeps the header information consistent with the actual file size.

  Changes Implemented

   - `main.c`:
       - Added a -d command-line option to handle employee deletion.
       - Orchestrates the deletion process by calling delete_employee, decrementing the header->count, and reallocating the employees array to the new size.
   - `parse.c`:
       - delete_employee(): New function that finds the specified employee by name and shifts the remaining elements of the array to fill the gap.
       - output_file(): Now uses ftruncate() to ensure the database file is correctly resized (shrunk or expanded) to match its new content length. This is critical for preventing 
         file corruption on deletion.

How to Use
To delete an employee, use the new -d flag followed by the employee's name in quotes:
`./bin/dbview -f ./mynewdb.db -d "Timmy H."`
